### PR TITLE
added file upload to amazon s3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/file-management "0.6.0"
+(defproject clanhr/file-management "0.7.0"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Added file upload to amazon s3 and get file url functions.
With this new functions we are able to upload any kind of files to s3.

Usage:

```
  Inputs: - credentials {:bucket
                         :access-key
                         :secret}
          - file-key We ensure an unique file key by concating an uuid, if nil we generate an unique file-key.
          - file-value {:value ;file-content
                        :content-type }

  Returns: file url to s3

  (file-management/put-file credentials-hash file-key file-info)
```

ref: https://github.com/clanhr/mothership/issues/1266
