### PR TITLE
Simplify the function interface to upload files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/file-management "0.7.0"
+(defproject clanhr/file-management "0.7.1"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"

--- a/src/file_management/core.clj
+++ b/src/file_management/core.clj
@@ -62,7 +62,9 @@
   (str file-key "_" (java.util.UUID/randomUUID)))
 
 (defn put-file
-  [credentials file-key file]
+  ([credentials file]
+    (put-file credentials nil file))
+  ([credentials file-key file]
   "Inputs: - credentials {:bucket
                           :access-key
                           :secret}
@@ -78,4 +80,4 @@
                    (:value file)
                    {:content-type (:content-type file)}
                    (s3/grant :all-users :read))
-    (get-file-url credentials file-key)))
+    (get-file-url credentials file-key))))


### PR DESCRIPTION
Now you don't need to call the put-file function with the file-key
option. So now we have the following 2 options to call this function:

```
(file-management/put-file credentials-hash file-key file-info)
(file-management/put-file credentials-hash file-info)
```

ref: https://github.com/clanhr/mothership/issues/1266
