### PR TITLE
add an async interface to put-file fn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: clojure
 lein: lein2
+jdk:
+ - oraclejdk8

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/file-management "0.7.1"
+(defproject clanhr/file-management "0.7.2"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
@@ -7,8 +7,10 @@
 
   :dependencies.edn "https://raw.githubusercontent.com/clanhr/dependencies/master/dependencies.edn"
 
-  :dependency-sets [:clojure :common]
-  :dependencies [[clj-aws-s3 "0.3.10"]
-                 [commons-codec/commons-codec "1.9"]]
+  :dependency-sets [:clojure
+                    :common
+                    :clanhr]
+
+  :dependencies []
 
   :plugins [[clanhr/shared-deps "0.2.6"]])


### PR DESCRIPTION
Added an async interface to put-file function.  Now the put-file
function returns immediately. Added a result/success or result/failure
to the returned value.
