### PR TITLE
Remove shared deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,10 @@
-(defproject clanhr/file-management "0.7.3"
+(defproject clanhr/file-management "0.7.4"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
 
-  :dependencies.edn "https://raw.githubusercontent.com/clanhr/dependencies/master/dependencies.edn"
-
-  :dependency-sets [:clojure
-                    :common
-                    :clanhr]
-
-  :dependencies []
-
-  :plugins [[clanhr/shared-deps "0.2.6"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clanhr/result "0.11.0"]
+                 [clj-aws-s3 "0.3.10"]])


### PR DESCRIPTION
Motivation:

Shared deps brings a heavy burden on a project. lein deps :tree takes 60s with
shared deps, and 3s without it. So we'll start using shared deps only on the
services.
